### PR TITLE
Ensure `request.expired_user` is set, allow forced password changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fp:
 
 setuptools.setup(
     name="django-password-expire",
-    version="3.0",
+    version="4.0",
     description="Django app for forcing password expiration",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Also guard against `kwargs['using']` not being set